### PR TITLE
Add specific width and height to images

### DIFF
--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -23,6 +23,8 @@ interface Props {
             draggable="false"
             loading="eager"
             format="avif"
+            width="800"
+            height="460"
         />
     </div>
     <h3 class="mt-2 text-xl font-bold text-neutral-800 group-hover:text-orange-400 dark:text-neutral-200 dark:group-hover:text-orange-300">

--- a/src/components/blog/BlogInsight.astro
+++ b/src/components/blog/BlogInsight.astro
@@ -22,6 +22,8 @@ interface Props {
             alt={blog.data.title}
             format="avif"
             loading="lazy"
+            width="850"
+            height="440"
         />
     </div>
 

--- a/src/components/blog/blocks/LeftSection.astro
+++ b/src/components/blog/blocks/LeftSection.astro
@@ -24,6 +24,8 @@ interface Props {
         alt={imgAlt}
         draggable="false"
         loading="lazy"
+        width="850"
+        height="420"
     />
 
     <div class="mt-4 md:mt-0">

--- a/src/components/blog/blocks/RightSection.astro
+++ b/src/components/blog/blocks/RightSection.astro
@@ -52,6 +52,8 @@ interface Props {
                         alt={imgOneAlt}
                         format="avif"
                         loading="lazy"
+                        width="850"
+                        height="420"
                     />
                 </div>
             )
@@ -64,6 +66,8 @@ interface Props {
                         draggable="false"
                         format="avif"
                         loading="lazy"
+                        width="400"
+                        height="230"
                     />
                     <Image
                         class="mt-4 w-full rounded-xl lg:mt-10"
@@ -72,6 +76,8 @@ interface Props {
                         draggable="false"
                         format="avif"
                         loading="lazy"
+                        width="400"
+                        height="230"
                     />
                 </div>
             )


### PR DESCRIPTION
This update adds definite width and height attributes to images used in the BlogCard, LeftSection, BlogInsight, and RightSection components. This will ensure the images always display properly and improve loading behavior by preventing layout shifts.